### PR TITLE
Merge in useful changes from abandoned branch

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ limitations under the License.
           </div>
           <div class="nodesbar">
           </div>
-	    <div class="demo flowchart-demo" id="sheet">
+	        <div class="demo flowchart-demo" id="sheet">
           </div>
         </div>
   </body>

--- a/script.js
+++ b/script.js
@@ -406,6 +406,7 @@ function refresh(instance) {
 
 	$.when(loadData()).then(function() {
     try {
+      instance.reset();
       groupByName();
       $('#sheet').empty();
       renderNodes();

--- a/script.js
+++ b/script.js
@@ -406,16 +406,16 @@ function refresh(instance) {
 
 	$.when(loadData()).then(function() {
     try {
-      instance.reset();
       groupByName();
       $('#sheet').empty();
       renderNodes();
       renderGroups();
       connectEverything();
+      instance.reset();
     } finally {
       setTimeout(function() {
         refresh(instance);
-      }, 1000);
+      }, 2000);
     }
   });
 }


### PR DESCRIPTION
We forked this from https://github.com/saturnism/gcp-live-k8s-visualizer ... which had a `kubernetes-1.2` ... which had these changes.

I don't claim to know what exactly these changes do in detail ... but I do know that it includes changes that we want i.e. works with Deployments ([e3863e3a][1]) ... and fixes for Kubernetes 1.5  ([0b18f3e6][2]).

Will work off `master` going forward.

[1]: https://github.com/Intellection/kubernetes-visualizer/commit/e3863e3a576d6ccd0fa4f5d1bba94f1294d7cfb1
[2]: https://github.com/Intellection/kubernetes-visualizer/commit/0b18f3e64587d647bd953116e48b61f5eef0978e